### PR TITLE
changed User.id to Owner.id per Error

### DIFF
--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -115,7 +115,7 @@ router
             where:{
                 id:req.params.spotId
             },
-            group:[['Spot.id'],['SpotImages.id'],['User.id']],
+            group:[['Spot.id'],['SpotImages.id'],['Owner.id']],
             include:[{
                 model:Review,
                 attributes:[]


### PR DESCRIPTION
new error asks for From clause entry for table User. last error metioned Owner id, because Users is aliased as Owner. So instead of using User.id i changed the group clause to include Owner.id.