### PR TITLE
SpotImages.url must appear in GROUP cluase

### DIFF
--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -90,7 +90,7 @@ router
                 ],
             },
             where:{ownerId:req.user.id},
-            group:['Spot.id'],
+            group:['Spot.id','SpotImage.url'],
             include:[{
                 model:Review,
                 attributes:[]


### PR DESCRIPTION
this error occurs when when trying to find all spots owned by current user. added SpotImage.url to group option in Spot.findAll()